### PR TITLE
34 field geocodingprovidergmapkey triggers contao error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "contao/core-bundle": "~4.9",
         "webexmachina/contao-utils": "^1.0",
         "phpoffice/phpspreadsheet": "^1.21",
-        "terminal42/dcawizard":"^2.5"
+        "terminal42/dcawizard": "^2.5",
+        "plenta/contao-encryption": "^2.0"
     },
     "require-dev":
     {

--- a/src/Resources/contao/dca/tl_wem_map.php
+++ b/src/Resources/contao/dca/tl_wem_map.php
@@ -192,9 +192,15 @@ $GLOBALS['TL_DCA']['tl_wem_map'] = [
         'geocodingProviderGmapKey' => [
             'label' => &$GLOBALS['TL_LANG']['tl_wem_map']['geocodingProviderGmapKey'],
             'exclude' => true,
-            'inputType' => 'textStore',
-            'eval' => ['mandatory' => true, 'maxlength' => 255, 'encrypt' => true],
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'maxlength' => 255],
             'sql' => "varchar(255) NOT NULL default ''",
+            'load_callback' => [
+                ['plenta.encryption', 'decrypt']
+            ],
+            'save_callback' => [
+                ['plenta.encryption', 'encrypt']
+            ],
         ],
 
         // {categories_legend},categories


### PR DESCRIPTION
Fix the encrypt issue by adding plenta/encryption as dependency. We use it a lot elsewhere, and we might use it for other map keys in the future.